### PR TITLE
chore: bump workload to v2.0.1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,6 @@ CONTRIBUTING.md # Contributing
 
 ```bash
 rockcraft pack -v
-sudo skopeo --insecure-policy copy oci-archive:sdcore-upf-pfcpiface_1.4.0_amd64.rock docker-daemon:sdcore-upf-pfcpiface:1.4.0
-docker run sdcore-upf-pfcpiface:1.4.0
+sudo rockcraft.skopeo --insecure-policy copy oci-archive:sdcore-upf-pfcpiface_2.0.1_amd64.rock docker-daemon:sdcore-upf-pfcpiface:2.0.1
+docker run sdcore-upf-pfcpiface:2.0.1
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-CONTRIBUTING.md # Contributing
+# Contributing
 
 ## Build and deploy
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
- # SD-Core UPF PFCPIFACE rock
+# SD-Core UPF PFCPIFACE rock
 
 Container image for SD-Core UPF PFCPIFACE, used in SD-Core UPF.
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,6 @@ Container image for SD-Core UPF PFCPIFACE, used in SD-Core UPF.
 ## Usage
 
 ```console
-docker pull ghcr.io/canonical/sdcore-upf-pfcpiface:2.0.0
-docker run -it ghcr.io/canonical/sdcore-upf-pfcpiface:2.0.0
+docker pull ghcr.io/canonical/sdcore-upf-pfcpiface:2.0.1
+docker run -it ghcr.io/canonical/sdcore-upf-pfcpiface:2.0.1
 ```

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -2,7 +2,7 @@
 name: sdcore-upf-pfcpiface
 base: bare
 build-base: ubuntu@24.04
-version: '2.0.0'
+version: '2.0.1'
 summary: SD-Core UPF PFCPIFACE
 description: SD-Core UPF PFCPIFACE
 license: Apache-2.0


### PR DESCRIPTION
# Description

Bump workload to latest release from upstream: v2.0.1

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
